### PR TITLE
Backport fix for LineageOS issue #492 to Pie

### DIFF
--- a/net/ipv4/route.c
+++ b/net/ipv4/route.c
@@ -2985,14 +2985,13 @@ struct rtable *ip_route_output_flow(struct net *net, struct flowi4 *flp4,
 }
 EXPORT_SYMBOL_GPL(ip_route_output_flow);
 
-static int rt_fill_info(struct net *net,
+static int rt_fill_info(struct net *net, struct flowi4 *fl4,
 			struct sk_buff *skb, u32 pid, u32 seq, int event,
 			int nowait, unsigned int flags)
 {
 	struct rtable *rt = skb_rtable(skb);
 	struct rtmsg *r;
 	struct nlmsghdr *nlh;
-	struct flowi4 *fl4 = &(inet_sk(skb->sk))->cork.fl.u.ip4;
 	unsigned long expires = 0;
 	const struct inet_peer *peer = rt->peer;
 	u32 id = 0, ts = 0, tsage = 0, error;
@@ -3106,6 +3105,7 @@ static int inet_rtm_getroute(struct sk_buff *in_skb, struct nlmsghdr* nlh, void 
 	struct rtmsg *rtm;
 	struct nlattr *tb[RTA_MAX+1];
 	struct rtable *rt = NULL;
+	struct flowi4 fl4;
 	__be32 dst = 0;
 	__be32 src = 0;
 	u32 iif;
@@ -3145,6 +3145,14 @@ static int inet_rtm_getroute(struct sk_buff *in_skb, struct nlmsghdr* nlh, void 
 	else
 		uid = (iif ? INVALID_UID : current_uid());
 
+	memset(&fl4, 0, sizeof(fl4));
+	fl4.daddr = dst;
+	fl4.saddr = src;
+	fl4.flowi4_tos = rtm->rtm_tos;
+	fl4.flowi4_oif = tb[RTA_OIF] ? nla_get_u32(tb[RTA_OIF]) : 0;
+	fl4.flowi4_mark = mark;
+	fl4.flowi4_uid = uid;
+
 	if (iif) {
 		struct net_device *dev;
 
@@ -3165,14 +3173,6 @@ static int inet_rtm_getroute(struct sk_buff *in_skb, struct nlmsghdr* nlh, void 
 		if (err == 0 && rt->dst.error)
 			err = -rt->dst.error;
 	} else {
-		struct flowi4 fl4 = {
-			.daddr = dst,
-			.saddr = src,
-			.flowi4_tos = rtm->rtm_tos,
-			.flowi4_oif = tb[RTA_OIF] ? nla_get_u32(tb[RTA_OIF]) : 0,
-			.flowi4_mark = mark,
-			.flowi4_uid = uid,
-		};
 		rt = ip_route_output_key(net, &fl4);
 
 		err = 0;
@@ -3187,7 +3187,7 @@ static int inet_rtm_getroute(struct sk_buff *in_skb, struct nlmsghdr* nlh, void 
 	if (rtm->rtm_flags & RTM_F_NOTIFY)
 		rt->rt_flags |= RTCF_NOTIFY;
 
-	err = rt_fill_info(net, skb, NETLINK_CB(in_skb).pid, nlh->nlmsg_seq,
+	err = rt_fill_info(net, &fl4, skb, NETLINK_CB(in_skb).pid, nlh->nlmsg_seq,
 			   RTM_NEWROUTE, 0, 0);
 	if (err <= 0)
 		goto errout_free;
@@ -3225,8 +3225,8 @@ int ip_rt_dump(struct sk_buff *skb,  struct netlink_callback *cb)
 			if (rt_is_expired(rt))
 				continue;
 			skb_dst_set_noref(skb, &rt->dst);
-			if (rt_fill_info(net, skb, NETLINK_CB(cb->skb).pid,
-					 cb->nlh->nlmsg_seq, RTM_NEWROUTE,
+			if (rt_fill_info(net, &(inet_sk(skb->sk))->cork.fl.u.ip4, skb,
+					 NETLINK_CB(cb->skb).pid, cb->nlh->nlmsg_seq, RTM_NEWROUTE,
 					 1, NLM_F_MULTI) <= 0) {
 				skb_dst_drop(skb);
 				rcu_read_unlock_bh();


### PR DESCRIPTION
_First of all, thanks for the work you've been doing on this kernel!_
_Let me know if you prefer to receive patch submissions via another medium than GitHub._

---

Unofficial LineageOS 16.0 builds for Google's Nexus 7 (2013), such as https://lineageos.wickenberg.nu/deb, include a kernel built from this branch (thanks to XDA Developers user `pitrus-`).

Unfortunately, a variety of popular apps - such as Firefox Mobile (https://github.com/mozilla-mobile/fenix/issues/5663#issuecomment-671612828) - have been causing OS crashes on this release for quite a while due to a critical patch that wasn't backported to `android_kernel_google_msm` for Pie.

Ref. https://gitlab.com/LineageOS/issues/android/issues/492

The commit in this pull request is a 100% unmodified backport of https://github.com/LineageOS/android_kernel_cyanogen_msm8974/commit/f44b4b19da1541fce8440ffa1e59cdb722cf10b5 (which was itself later backported to `android_kernel_google_msm` in v18.1 via https://github.com/LineageOS/android_kernel_google_msm/commit/e4cede11f4bed0fec727e0cdfb2d8176952bd7d5).